### PR TITLE
Fix CLI config override key

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -86,8 +86,9 @@ def main(  # noqa: PLR0913 - many CLI options are expected
         "model_config",
     ]
     overrides = _collect_cli_options(ctx, cli_values, option_names)
-    if model_config is not None:
-        overrides["config"] = model_config
+    config_override = overrides.pop("model_config", None)
+    if config_override is not None:
+        overrides["config"] = config_override
 
     config = load_config(overrides)
     setup_logging(config.log_file, verbose=verbose)


### PR DESCRIPTION
## Summary
- prevent passing both `model_config` and `config` keys from CLI overrides
- ensure `--config` option is forwarded using the expected `config` key so `load_config` accepts it

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d422bf33148323af6afc19eab05ac1